### PR TITLE
[Event] Hacktoberfest 2023: disable signup form #5888

### DIFF
--- a/src/collections/events/2023/hacktoberfest-2023/index.mdx
+++ b/src/collections/events/2023/hacktoberfest-2023/index.mdx
@@ -9,7 +9,7 @@ type: Event
 speakers: ["Gaurav Chadha", "Pranav Singh", "Uzair Shaikh", "Yash Sharma", "Anita Ihuman", "Saurabh Soni", "Ritik Saxena", "Senali Dilumika", "Sudhanshu Dasgupta", "Rex Joshua Ibegbu"]
 published: true
 upcoming: true
-register: true
+register: false
 ---
 
 import { Link } from "gatsby" ;


### PR DESCRIPTION
updated index.mdx and set register to false

**Description**

This PR fixes #
it fixes the register tab that was popping up on https://layer5.io/community/events/hacktoberfest-prep-2023-easing-into-cncf-open-source-projects page by fixing " register:true" to " register:false" at index.mdx file.
 
**Notes for Reviewers**
i have changed the file in the directory   src/collections/events/hacktoberfest/index.mdx where i have set register:false as asked in the issue #5888.

**[Signed commits](https://github.com/layer5io/layer5/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Layer5 projects! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
